### PR TITLE
chore : JpaRepository Method Call할 수 있도록 과정수정 및 테스트 샘플 추가

### DIFF
--- a/Api/src/main/java/picasso/server/api/Application.java
+++ b/Api/src/main/java/picasso/server/api/Application.java
@@ -5,9 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
 
 @Slf4j
 @EntityScan("picasso.server.domain")
+@ComponentScan("picasso.server.domain")
 @SpringBootApplication
 @RequiredArgsConstructor
 public class Application {

--- a/Api/src/main/java/picasso/server/api/TestService.java
+++ b/Api/src/main/java/picasso/server/api/TestService.java
@@ -1,0 +1,21 @@
+package picasso.server.api;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import picasso.server.domain.domains.test.Test;
+import picasso.server.domain.domains.test.TestRepository;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TestService {
+    private final TestRepository testRepository;
+
+
+    public Optional<Test> test() {
+        return testRepository.findById(1L);
+    }
+}

--- a/Domain/build.gradle
+++ b/Domain/build.gradle
@@ -2,7 +2,7 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api 'org.springframework.boot:spring-boot-starter-validation'
     api 'com.mysql:mysql-connector-j:8.0.33'
 

--- a/Domain/src/main/java/picasso/server/domain/domains/test/Test.java
+++ b/Domain/src/main/java/picasso/server/domain/domains/test/Test.java
@@ -21,4 +21,10 @@ public class Test {
 
     @Column
     private String name;
+
+    private String param1;
+    private String param2;
+    private String param3;
+    private String param4;
+
 }

--- a/Domain/src/main/java/picasso/server/domain/domains/test/TestRepository.java
+++ b/Domain/src/main/java/picasso/server/domain/domains/test/TestRepository.java
@@ -1,0 +1,8 @@
+package picasso.server.domain.domains.test;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TestRepository extends JpaRepository<Test, Long> {
+
+}


### PR DESCRIPTION
- Main ComponentScan을 Domain영역 추가
- Domain모듈에서 JPA를 implemention참조가아닌 API참조로 수정 - 변경한 사유는 implemention인 경우에는 Api모듈에서 JpaRepository인터페이스의 사용이 불가능해지지만, api를 통한 빌드를 할 경우에는 활요이 가능해진다.
- Domain에서 작성해야하는 Entity, Repository의 Sample Code 작성


## IssueNumver
#10 